### PR TITLE
Fix type warning in numpy slicing

### DIFF
--- a/pyeeg/__init__.py
+++ b/pyeeg/__init__.py
@@ -218,10 +218,10 @@ def bin_power(X, Band, Fs):
         Freq = float(Band[Freq_Index])
         Next_Freq = float(Band[Freq_Index + 1])
         Power[Freq_Index] = sum(
-            C[numpy.floor(
-                Freq / Fs * len(X)
-            ): numpy.floor(Next_Freq / Fs * len(X))]
+            C[int(numpy.floor(Freq / Fs * len(X))):
+                int(numpy.floor(Next_Freq / Fs * len(X)))]
         )
+
     Power_Ratio = Power / sum(Power)
     return Power, Power_Ratio
 


### PR DESCRIPTION
Hi, thank you for providing pyeeg !


I found a tweak warning, so I fix it and send this PR.

Using float object to slice array, python raise a warning like bellow.

> VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  ): numpy.floor(Next_Freq / Fs * len(X))]

So I have converted numpy.floor(・) to Integer.

If you have some reasons to ignore this warning, please reject this pull request.

Thanks.