### PR TITLE
Fixed bin_power slice index exception

### DIFF
--- a/pyeeg/__init__.py
+++ b/pyeeg/__init__.py
@@ -218,9 +218,9 @@ def bin_power(X, Band, Fs):
         Freq = float(Band[Freq_Index])
         Next_Freq = float(Band[Freq_Index + 1])
         Power[Freq_Index] = sum(
-            C[numpy.floor(
+            C[int(numpy.floor(
                 Freq / Fs * len(X)
-            ): numpy.floor(Next_Freq / Fs * len(X))]
+            )): int(numpy.floor(Next_Freq / Fs * len(X)))]
         )
     Power_Ratio = Power / sum(Power)
     return Power, Power_Ratio


### PR DESCRIPTION
On python 3.6 i was getting an index slice error because the indexes into the C list were floats, not ints. I've cast them in this PR, and that seems to fix the issue.