### PR TITLE
Add compulsory type conversion to bin_power

### DIFF
--- a/pyeeg/__init__.py
+++ b/pyeeg/__init__.py
@@ -218,9 +218,9 @@ def bin_power(X, Band, Fs):
         Freq = float(Band[Freq_Index])
         Next_Freq = float(Band[Freq_Index + 1])
         Power[Freq_Index] = sum(
-            C[numpy.floor(
+            C[int(numpy.floor(
                 Freq / Fs * len(X)
-            ): numpy.floor(Next_Freq / Fs * len(X))]
+            )): int(numpy.floor(Next_Freq / Fs * len(X)))]
         )
     Power_Ratio = Power / sum(Power)
     return Power, Power_Ratio


### PR DESCRIPTION
Hi professor Bao! 
The  pyeeg reported "TypeError: slice indices must be integers or None or have an __index__ method" when I was using the  bin_power() function with  py3.6. I also tried it in py2.7 but the same error was reported. Then I found that with compulsory type conversion added to the parameters :numpy.floor(Freq / Fs * len(X)) and numpy.floor(Next_Freq / Fs * len(X)), it finally works.
So, I think this change many be safier and less confused to the other users.
Thank you for your work and your contribution to this program!!! 
过年好！