### PR TITLE
Bugfix for sample entropy: last template vector of length M must be ignored

### DIFF
--- a/pyeeg/entropy.py
+++ b/pyeeg/entropy.py
@@ -312,7 +312,7 @@ def samp_entropy(X, M, R):
 
     N = len(X)
 
-    Em = embed_seq(X, 1, M)
+    Em = embed_seq(X, 1, M)[:-1]
     A = numpy.tile(Em, (len(Em), 1, 1))
     B = numpy.transpose(A, [1, 0, 2])
     D = numpy.abs(A - B)  # D[i,j,k] = |Em[i][k] - Em[j][k]|
@@ -324,7 +324,7 @@ def samp_entropy(X, M, R):
         numpy.tile(X[M:], (N - M, 1)) - numpy.tile(X[M:], (N - M, 1)).T
     )
 
-    Cmp = numpy.logical_and(Dp <= R, InRange[:-1, :-1]).sum(axis=0)
+    Cmp = numpy.logical_and(Dp <= R, InRange).sum(axis=0)
 
     # Avoid taking log(0)
     Samp_En = numpy.log(numpy.sum(Cm + 1e-100) / numpy.sum(Cmp + 1e-100))


### PR DESCRIPTION
@DominiqueMakowski called my attention to a discrepancy between this implementation of the sample entropy and my implementation in [nolds](https://github.com/CSchoel/nolds) in this issue: [neuropsychology/NeuroKit#53](https://github.com/neuropsychology/NeuroKit/issues/53) .

I think there is a small issue in pyeeg that causes this inconsistence: The sample entropy is the conditional probability that two pieces of the input sequence that are similar for M time steps will remain similar for M+1 time steps. If we count the number of similar template vector pairs of length M we therefore must ignore the last template vector, since it cannot be followed for another time step. If we would include it in the calculation, this would introduce a bias that underestimates the number of template vectors that remain similar for a length of M+1.

Reference: [Richman and Moorman (2000)](https://doi.org/10.1152/ajpheart.2000.278.6.H2039), page H2042

At Dominique's hint I found similar issues with entro-py (https://github.com/ixjlyons/entro-py/pull/2) and pyEntropy (https://github.com/nikdon/pyEntropy/pull/15). With the suggested fix in this pull request, pyeeg produces the same output as [nolds](https://github.com/CSchoel/nolds) and the R-package [pracma](https://github.com/cran/pracma/blob/master/R/entropy.R) (which I used as reference for the implementation of nolds), as well as the fixed versions of pyEntropy and entro-py,

```python
import nolds
import entropy as e
import pyentrp.entropy as pent
import pyeeg.entropy as peeg
import numpy as np

num = 100
dim = 2
tol = 0.2
signal = np.cos(np.linspace(start=0, stop=30, num=num))
print("entro-py", e.sampen(signal, dim, tol, False))
print(" pyentrp", pent.sample_entropy(signal, dim + 1, tol)[-1])
print("   pyeeg", peeg.samp_entropy(signal, dim, tol))
print("   nolds", nolds.sampen(signal, emb_dim=dim, tolerance=tol))
```
```
entro-py 0.27672305866206137
 pyentrp 0.2767230586620615
   pyeeg 0.27672305866206137
   nolds 0.2767230586620615
```