### PR TITLE
import bin_power function

### DIFF
--- a/pyeeg/entropy.py
+++ b/pyeeg/entropy.py
@@ -1,6 +1,6 @@
 import numpy
 from .embedded_sequence import embed_seq
-
+from .spectrum import bin_power
 
 def ap_entropy(X, M, R):
     """Computer approximate entropy (ApEN) of series X, specified by M and R.


### PR DESCRIPTION
Call of spectral_entropy function did not recognize bin_power, as it isnot included from spectrum.py.